### PR TITLE
Revert "keep cluster alive in prod for historical data loads (#44)"

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -134,7 +134,7 @@ locals {
     qa          = false
     integration = false
     preprod     = false
-    production  = true
+    production  = false
   }
 
   step_fail_action = {


### PR DESCRIPTION
This reverts commit 070b187c30a32ac2b1a780c0f94aaa9398082cb6.